### PR TITLE
Fix errors due to missing data in the API

### DIFF
--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -51,7 +51,7 @@ SENSOR_TYPES = {
         ENTITY_UNIT: UNIT_PERCENTAGE,
         ENTITY_ICON: "mdi:weather-snowy",
         ENTITY_CLASS: None,
-        ENTITY_ENABLE: False,
+        ENTITY_ENABLE: True,
         ENTITY_API_DATA_PATH: "probability_forecast:snow:3h",
     },
     "freeze_chance": {

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -132,7 +132,13 @@ CONDITION_CLASSES = {
     "hail": ["Risque de grêle"],
     "lightning": ["Risque d'orages", "Orages"],
     "lightning-rainy": ["Pluie orageuses", "Pluies orageuses", "Averses orageuses"],
-    "partlycloudy": ["Ciel voilé", "Ciel voilé nuit", "Éclaircies", "Eclaircies"],
+    "partlycloudy": [
+        "Ciel voilé",
+        "Ciel voilé nuit",
+        "Éclaircies",
+        "Eclaircies",
+        "Peu nuageux",
+    ],
     "pouring": ["Pluie forte"],
     "rainy": [
         "Bruine / Pluie faible",

--- a/homeassistant/components/meteo_france/const.py
+++ b/homeassistant/components/meteo_france/const.py
@@ -122,7 +122,7 @@ SENSOR_TYPES = {
 
 CONDITION_CLASSES = {
     "clear-night": ["Nuit Claire", "Nuit claire"],
-    "cloudy": ["Très nuageux"],
+    "cloudy": ["Très nuageux", "Couvert"],
     "fog": [
         "Brume ou bancs de brouillard",
         "Brume",

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -253,6 +253,10 @@ class MeteoFranceAlertSensor(MeteoFranceSensor):
 def _find_first_probability_forecast_not_null(
     probability_forecast: list, path: list
 ) -> int:
-    for forecast in probability_forecast:
+    """Search the first not None value in the first forecast elements."""
+    for forecast in probability_forecast[0:3]:
         if forecast[path[1]][path[2]] is not None:
             return forecast[path[1]][path[2]]
+
+    # Default return value if no value founded
+    return None

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -117,12 +117,12 @@ class MeteoFranceSensor(Entity):
         try:
             if path[0] == "probability_forecast":
                 # TODO: return often 'null' with France cities. Need investigation
-                # TODO: "probability_forecast" not always available.
                 data = data[0]
 
             if len(path) == 3:
                 value = data[path[1]][path[2]]
-            value = data[path[1]]
+            else:
+                value = data[path[1]]
         except IndexError:
             _LOGGER.warning("Expected data missing in API results for %s", self.name)
             value = None

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -51,13 +51,14 @@ async def async_setup_entry(
                     coordinator_forecast.data.position["name"],
                 )
 
-        elif sensor_type == "weather_alert" and coordinator_alert:
-            entities.append(MeteoFranceAlertSensor(sensor_type, coordinator_alert))
-            _LOGGER.debug(
-                "Weather alert sensor for department n°%s added with %s.",
-                coordinator_forecast.data.position["dept"],
-                coordinator_forecast.data.position["name"],
-            )
+        elif sensor_type == "weather_alert":
+            if coordinator_alert:
+                entities.append(MeteoFranceAlertSensor(sensor_type, coordinator_alert))
+                _LOGGER.debug(
+                    "Weather alert sensor for department n°%s added with %s.",
+                    coordinator_forecast.data.position["dept"],
+                    coordinator_forecast.data.position["name"],
+                )
         elif sensor_type in ["rain_chance", "freeze_chance", "snow_chance"]:
             if coordinator_forecast.data.probability_forecast:
                 entities.append(MeteoFranceSensor(sensor_type, coordinator_forecast))

--- a/homeassistant/components/meteo_france/sensor.py
+++ b/homeassistant/components/meteo_france/sensor.py
@@ -113,24 +113,21 @@ class MeteoFranceSensor(Entity):
         """Return the state."""
         path = SENSOR_TYPES[self._type][ENTITY_API_DATA_PATH].split(":")
         data = getattr(self.coordinator.data, path[0])
-        try:
-            # Specific case for probability forecast
-            if path[0] == "probability_forecast":
-                if len(path) == 3:
-                    # This is a fix compared to other entitty as first index is always null in API result for unknown reason
-                    value = _find_first_probability_forecast_not_null(data, path)
-                else:
-                    value = data[0][path[1]]
 
-            # General case
+        # Specific case for probability forecast
+        if path[0] == "probability_forecast":
+            if len(path) == 3:
+                # This is a fix compared to other entitty as first index is always null in API result for unknown reason
+                value = _find_first_probability_forecast_not_null(data, path)
             else:
-                if len(path) == 3:
-                    value = data[path[1]][path[2]]
-                else:
-                    value = data[path[1]]
-        except IndexError:
-            _LOGGER.warning("Expected data is missing in API results for %s", self.name)
-            value = None
+                value = data[0][path[1]]
+
+        # General case
+        else:
+            if len(path) == 3:
+                value = data[path[1]][path[2]]
+            else:
+                value = data[path[1]]
 
         if self._type == "wind_speed":
             # convert API wind speed from m/s to km/h
@@ -254,8 +251,8 @@ class MeteoFranceAlertSensor(MeteoFranceSensor):
 
 
 def _find_first_probability_forecast_not_null(
-    probability_forecast: list, path: dict
+    probability_forecast: list, path: list
 ) -> int:
-    for timestamp in probability_forecast:
-        if timestamp[path[1]][path[2]] is not None:
-            return timestamp[path[1]][path[2]]
+    for forecast in probability_forecast:
+        if forecast[path[1]][path[2]] is not None:
+            return forecast[path[1]][path[2]]


### PR DESCRIPTION
- `probability_forecast` not always in API results
- fix an algorithm error to avoid having `weather alert` entity created even if no data are available
- Add `peu nuageux` in condition map
- fix an algorithm error to avoid overwritting sensor value with wrong data
- enable `snow_chance` entity by default
- workaround to the always first null value for rain and snow chance entities