### PR TITLE
freebox with home / dathosim

### DIFF
--- a/homeassistant/components/freebox/alarm_control_panel.py
+++ b/homeassistant/components/freebox/alarm_control_panel.py
@@ -131,21 +131,21 @@ class FreeboxAlarm(FreeboxHomeBaseClass, AlarmControlPanelEntity):
         """Send disarm command."""
         if await self.set_home_endpoint_value(self._command_off):
             self._state = STATE_ALARM_DISARMED
-            self.start_watcher(timedelta(seconds=1))
+            """self.start_watcher(timedelta(seconds=1))"""
             self.async_write_ha_state()
 
     async def async_alarm_arm_away(self, code=None) -> None:
         """Send arm away command."""
         if await self.set_home_endpoint_value(self._command_alarm1):
             self._state = STATE_ALARM_ARMING
-            self.start_watcher(timedelta(seconds=self._timeout1 + 1))
+            """self.start_watcher(timedelta(seconds=self._timeout1 + 1))"""
             self.async_write_ha_state()
 
     async def async_alarm_arm_night(self, code=None) -> None:
         """Send arm night command."""
         if await self.set_home_endpoint_value(self._command_alarm2):
             self._state = STATE_ALARM_ARMING
-            self.start_watcher(timedelta(seconds=self._timeout1 + 1))
+            """self.start_watcher(timedelta(seconds=self._timeout1 + 1))"""
             self.async_write_ha_state()
 
     async def async_watcher(self, now: Optional[datetime] = None) -> None:

--- a/homeassistant/components/freebox/alarm_control_panel.py
+++ b/homeassistant/components/freebox/alarm_control_panel.py
@@ -131,21 +131,21 @@ class FreeboxAlarm(FreeboxHomeBaseClass, AlarmControlPanelEntity):
         """Send disarm command."""
         if await self.set_home_endpoint_value(self._command_off):
             self._state = STATE_ALARM_DISARMED
-            """self.start_watcher(timedelta(seconds=1))"""
+            self.start_watcher(timedelta(seconds=1))
             self.async_write_ha_state()
 
     async def async_alarm_arm_away(self, code=None) -> None:
         """Send arm away command."""
         if await self.set_home_endpoint_value(self._command_alarm1):
             self._state = STATE_ALARM_ARMING
-            """self.start_watcher(timedelta(seconds=self._timeout1 + 1))"""
+            self.start_watcher(timedelta(seconds=self._timeout1 + 1))
             self.async_write_ha_state()
 
     async def async_alarm_arm_night(self, code=None) -> None:
         """Send arm night command."""
         if await self.set_home_endpoint_value(self._command_alarm2):
             self._state = STATE_ALARM_ARMING
-            """self.start_watcher(timedelta(seconds=self._timeout1 + 1))"""
+            self.start_watcher(timedelta(seconds=self._timeout1 + 1))
             self.async_write_ha_state()
 
     async def async_watcher(self, now: Optional[datetime] = None) -> None:

--- a/homeassistant/components/freebox/base_class.py
+++ b/homeassistant/components/freebox/base_class.py
@@ -4,6 +4,8 @@ from typing import Dict
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_time_interval
+from datetime import datetime, timedelta
 
 from .const import DOMAIN, VALUE_NOT_SET
 from .router import FreeboxRouter
@@ -52,6 +54,15 @@ class FreeboxHomeBaseClass(Entity):
         elif node["type"].get("inherit") == "node::ios":
             self._manufacturer = "Somfy"
             self._model = "IOHome"
+
+    def start_watcher(self, timedelta=timedelta(seconds=1)):
+         self._watcher = async_track_time_interval(self._hass, self.async_watcher, timedelta)
+
+    def stop_watcher(self):
+         if( self._watcher != None ):
+             self._watcher()
+             self._watcher = None
+
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/freebox/binary_sensor.py
+++ b/homeassistant/components/freebox/binary_sensor.py
@@ -74,7 +74,7 @@ class FreeboxPir(FreeboxHomeBaseClass, BinarySensorEntity):
             node["type"]["endpoints"], "signal", "trigger"
         )
         self._detection = False
-        self.start_watcher(timedelta(seconds=2))
+        """self.start_watcher(timedelta(seconds=2))"""
         self._had_timeout = False
 
     async def async_watcher(self, now: Optional[datetime] = None) -> None:

--- a/homeassistant/components/freebox/binary_sensor.py
+++ b/homeassistant/components/freebox/binary_sensor.py
@@ -74,7 +74,7 @@ class FreeboxPir(FreeboxHomeBaseClass, BinarySensorEntity):
             node["type"]["endpoints"], "signal", "trigger"
         )
         self._detection = False
-        """self.start_watcher(timedelta(seconds=2))"""
+        self.start_watcher(timedelta(seconds=2))
         self._had_timeout = False
 
     async def async_watcher(self, now: Optional[datetime] = None) -> None:

--- a/homeassistant/components/freebox/const.py
+++ b/homeassistant/components/freebox/const.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
 
 DOMAIN = "freebox"
 SERVICE_REBOOT = "reboot"
+VALUE_NOT_SET = ""
 
 APP_DESC = {
     "app_id": "hass",
@@ -26,7 +27,7 @@ PLATFORMS = [
     "cover",
     "alarm_control_panel",
     "camera",
-    "binary_sensor",
+    "binary_sensor"
 ]
 
 DEFAULT_DEVICE_NAME = "Unknown device"

--- a/homeassistant/components/freebox/const.py
+++ b/homeassistant/components/freebox/const.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
 
 DOMAIN = "freebox"
 SERVICE_REBOOT = "reboot"
-VALUE_NOT_SET = ""
+VALUE_NOT_SET = None
 
 APP_DESC = {
     "app_id": "hass",

--- a/homeassistant/components/freebox/manifest.json
+++ b/homeassistant/components/freebox/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/freebox",
   "requirements": ["freebox-api==0.0.10"],
-  "dependencies": ["ffmpeg", "generic"],
+  "dependencies": ["ffmpeg"],
   "zeroconf": ["_fbx-api._tcp.local."],
   "codeowners": ["@hacf-fr", "@Quentame", "@gvigroux"],
   "iot_class": "local_polling"

--- a/homeassistant/components/freebox/manifest.json
+++ b/homeassistant/components/freebox/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "freebox",
   "name": "Freebox",
+  "version": "1.15",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/freebox",
   "requirements": ["freebox-api==0.0.10"],


### PR DESCRIPTION
- init de la constante VALUE_NOT_SET manquante dans const.py (sinon erreur à l'init) 
- supression de la dependance a generic : sinon on passe pas le config flow
- suppression des start_watcher dans les binary sensor : sinon erreur à l'init - attribut n'existe pas

Après vérification, cela rend l'intégration installable mais l'update des sensor ne se fait pas.
En effet, il n'ya plus d'appel à un watcher ou updater lors du changement d'état (car j'ai  commenté les lignes self.start_watcher qui était en erreur)
J'ai beau remonté dans l'historique du code je n'arrive pas à comprendre comment cela devrait être codé pour que ça marche.

Mais au moins avec cette PR l'intégration peut être installé entièrement et détecte tous les device du pack sécurité 
